### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ void setup(){
   // Initialization as mentioned above
 
   // set the measurement to mm
-  tfmini.setFrameRate(TFMINI_MEASUREMENT_MM); //Ouputs a boolean   
+  tfmini.setMeasurementTo(TFMINI_MEASUREMENT_MM); //Ouputs a boolean   
 }
 ```
 


### PR DESCRIPTION
In the section Change the output format the example uses the method .setFrameRate(TFMINI_MEASUREMENT_MM); but it explains that should be used setMeasurementTo(TFMINI_MEASUREMENT_MM). I believe this could be a mistake from a copy/paste of the Frame rate section.